### PR TITLE
Of/gen server call timeout

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,10 +13,10 @@
 %% Add dependencies that are only needed for development here. These
 %% dependencies will be hidden from upstream projects using this code
 %% as a dependency.
-%% {dev_only_deps,
-%%  [
-%%   {hoax, ".*", {git, "git://github.com/xenolinguist/hoax.git", "master"}}
-%% ]}.
+ {dev_only_deps,
+  [
+   {meck, ".*", {git, "git://github.com/eproxus/meck.git", "master"}}
+ ]}.
 
 %% Use edown to render a markdown version of edoc. The generated
 %% markdown can be checked in and will be browsable on github. The

--- a/src/oc_httpc_worker.erl
+++ b/src/oc_httpc_worker.erl
@@ -37,7 +37,15 @@ start_link(RootUrl, IbrowseOptions, Config) ->
     gen_server:start_link(?MODULE, [RootUrl, IbrowseOptions, Config], []).
 
 request(Pid, Path, Headers, Method, Body, Timeout) when is_atom(Method) ->
-    gen_server:call(Pid, {request, Path, Headers, Method, Body, Timeout}, Timeout).
+    try gen_server:call(Pid, {request, Path, Headers, Method, Body, Timeout}, Timeout) of
+        Result ->
+            Result
+    catch
+        exit:{timeout, _} ->
+            {error, req_timedout};
+        Other ->
+            throw(Other)
+    end.
 
 multi_request(Pid, Fun, Timeout) ->
     RequestFun = fun(Path, Headers, Method, Body) when is_atom(Method) ->


### PR DESCRIPTION
There are some white space changes because the file need to be formatted.  Otherwise, two test cases added, one to establish the correct behavior during timeout and the other to force the error to be rethrown.
