### PR TITLE
Fix opscoderl_httpc (Erlang 24.x upgrade)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
     %% Pin here, becase 555f707 (pr #155) introduces an ipv6 bug we've not fixed
     {git, "https://github.com/cmullaparthi/ibrowse.git", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},
     {lager, ".*",
-        {git, "git://github.com/basho/lager.git", {branch, "master"}}},
+        {git, "https://github.com/basho/lager.git", {branch, "master"}}},
    {pooler, ".*",  %% use a catch all regex and peg with a tag if neded
      {git, "https://github.com/seth/pooler.git", {branch, "master"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,11 +6,11 @@
   [
    {ibrowse, ".*",
     %% Pin here, becase 555f707 (pr #155) introduces an ipv6 bug we've not fixed
-    {git, "https://github.com/cmullaparthi/ibrowse.git", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},
+    {git, "https://github.com/cmullaparthi/ibrowse", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},
     {lager, ".*",
-        {git, "https://github.com/basho/lager.git", {branch, "master"}}},
+        {git, "https://github.com/erlang-lager/lager", {ref, "a140ea935eae9149bb35234bb40f6acf1c69caa1"}}},
    {pooler, ".*",  %% use a catch all regex and peg with a tag if neded
-     {git, "https://github.com/seth/pooler.git", {branch, "master"}}}
+     {git, "https://github.com/chef/pooler", {branch, "master"}}}
 ]}.
 
 %% Add dependencies that are only needed for development here. These
@@ -18,11 +18,11 @@
 %% as a dependency.
 {profiles, [{test, [{deps,
                          [
-                          {meck, ".*", {git, "https://github.com/eproxus/meck.git", "master"}},
+                          {meck, ".*", {git, "https://github.com/eproxus/meck", {ref, "06192a984750070ace33b60a492ca27ec9bc6806"}}},
                           {observer_cli, ".*",
-                            {git, "https://github.com/zhongwencool/observer_cli.git", {branch, "master"}}},
+                            {git, "https://github.com/zhongwencool/observer_cli", {ref, "baa70569bccc5508e9839e20768540ef3cdca016"}}},
                           {eper, ".*",
-                           {git, "https://github.com/massemanet/eper.git", {branch, "master"}}}
+                           {git, "https://github.com/massemanet/eper", {ref, "17b0f97ea8287b72e8ebbe7132214db182ff1a1d"}}}
                          ]}]}
            ]}.
 

--- a/src/oc_httpc.erl
+++ b/src/oc_httpc.erl
@@ -35,7 +35,7 @@
         ]).
 
 -ifdef(TEST).
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 -endif.
 
 -define(DEFAULT_SINGLE_REQUEST_TIMEOUT, 30000).

--- a/src/oc_time.erl
+++ b/src/oc_time.erl
@@ -27,9 +27,9 @@
 convert_units({Val, SourceUnit}, TargetUnit) ->
     Val * to_ms(SourceUnit, TargetUnit).
 
-to_ms(_Unit, _Unit) ->
-    1;
 to_ms(min, ms) ->
     60000;
 to_ms(sec, ms) ->
-    1000.
+    1000;
+to_ms(Unit, Unit) ->
+    1.


### PR DESCRIPTION
@PrajaktaPurohit and/or @marcparadise should look at this before we proceed with merging, since there is a question as to what the intent of the original developer was, whether this is a bug or not, etc.

The following error was encountered during compilation:

```
===> Compiling src/oc_time.erl failed
src/oc_time.erl:32:1: this clause for to_ms/2 cannot match because a previous clause at line 30 always matches
src/oc_time.erl:34:1: this clause for to_ms/2 cannot match because a previous clause at line 30 always matches
```

My original hypothesis was that something changed in Erlang 24x to cause the first clause to always match, where as all clauses could match pre-Erlang24x.  To confirm the original behavior, I fired-up a dev vm loaded with latest stable:

```
root@api:~# chef-server-ctl version
14.15.10
root@api:~# cat /tmp/oc_time.erl

-module(oc_time).
-compile(export_all).

to_ms(_Unit1, _Unit2) ->
    1;
to_ms(min, ms) ->
    60000;
to_ms(sec, ms) ->
    1000.

root@api:~# erl
Erlang/OTP 22 [erts-10.6] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe]

1> cd("/tmp").
/tmp
ok
2> c(oc_time).
oc_time.erl:2: Warning: export_all flag enabled - all functions will be exported
oc_time.erl:6: Warning: this clause cannot match because a previous clause at line 4 always matches
oc_time.erl:8: Warning: this clause cannot match because a previous clause at line 4 always matches
{ok,oc_time}
3> oc_time:to_ms(x, y).
1
4> oc_time:to_ms(x, x).
1
5> oc_time:to_ms(min, ms).
1
6> oc_time:to_ms(sec, ms).
1
7> halt().
```
As depicted above, the first clause always matches no matter the input, even on stable main branch with pre-Erlang24.

On the surface, it looks like a bug, and not what the original developer would have intended.  However, Chef Infra Server seems to work fine with the current code as-is, so perhaps this was edited at some point in the past to "short circuit" the other clauses for some reason.  I did try to do some "git blame" to find out what changes might have happened here in the past, but didn't find anything.

Options:

1) Fix the compilation error, but keep the current behavior.  For now, unless instructed otherwise, I have chosen this path.

2) Fix the compilation error, and fix the function so that all clauses can match.  This can be easily done, e.g. if we play mind-reader, we can imagine that this (or similar) was the original intent:
```
-module(oc_time).
-compile(export_all).

to_ms(min, ms) ->
    60000;
to_ms(sec, ms) ->
    1000;
to_ms(_, _) ->
    1.
```