### PR TITLE
Update ibrowse

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,13 +4,14 @@
 
 {deps,
   [
-   {ibrowse, ".*",
-    %% Pin here, becase 555f707 (pr #155) introduces an ipv6 bug we've not fixed
-    {git, "https://github.com/cmullaparthi/ibrowse", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},
+    {envy, ".*",
+        {git, "https://github.com/markan/envy",         {branch, "master"}}},
+    {ibrowse, ".*",
+        {git, "https://github.com/chef/ibrowse",        {branch, "chef-server"}}},
     {lager, ".*",
-        {git, "https://github.com/erlang-lager/lager", {ref, "a140ea935eae9149bb35234bb40f6acf1c69caa1"}}},
-   {pooler, ".*",  %% use a catch all regex and peg with a tag if neded
-     {git, "https://github.com/chef/pooler", {branch, "master"}}}
+        {git, "https://github.com/erlang-lager/lager",  {ref, "a140ea935eae9149bb35234bb40f6acf1c69caa1"}}},
+    {pooler, ".*",  %% use a catch all regex and peg with a tag if neded
+        {git, "https://github.com/chef/pooler",         {branch, "master"}}}
 ]}.
 
 %% Add dependencies that are only needed for development here. These


### PR DESCRIPTION
ibrowse is on a different repo and branch than chef-server.

opscoderl_httpc:
    {git, "https://github.com/cmullaparthi/ibrowse", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},

chef-server:
    {git, "https://github.com/chef/ibrowse", {branch, "chef-server"}}},

NOTE: envy had to be pulled in to make this work.

```
$ ~/chef-server/src/bookshelf/rebar3 eunit
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling opscoderl_httpc
===> Performing EUnit tests...
<snip>
....
Finished in 6.213 seconds
34 tests, 0 failures
```